### PR TITLE
Phase 4: Composition Intelligence — strategies, templates, stems

### DIFF
--- a/src/dodgylegally/cli.py
+++ b/src/dodgylegally/cli.py
@@ -190,8 +190,9 @@ def process(ctx, input_path, effects, target_bpm, stretch, pitch, target_key):
 @click.option("--repeats", "-r", default="3-4", help="Repeat range for each loop (e.g. 3-4).")
 @click.option("--strategy", "-s", default="sequential", help="Arrangement strategy (sequential, loudness, tempo, key_compatible, layered).")
 @click.option("--template", "-t", default=None, help="Use an arrangement template (e.g. build-and-drop, ambient-drift).")
+@click.option("--stems", is_flag=True, default=False, help="Export individual stem files alongside full mix.")
 @click.pass_context
-def combine(ctx, input_dir, repeats, strategy, template):
+def combine(ctx, input_dir, repeats, strategy, template, stems):
     """Merge loop files into a combined file."""
     import os
     from dodgylegally.combine import combine_loops
@@ -205,7 +206,16 @@ def combine(ctx, input_dir, repeats, strategy, template):
 
     console = ctx.obj["console"]
 
-    if template:
+    if stems:
+        from dodgylegally.stems import export_stems
+        stem_dir = os.path.join(base, "stems")
+        result = export_stems(input_dir, stem_dir, repeats=repeat_range, strategy=strategy)
+        if result["tracks"]:
+            console.info(f"Exported {len(result['tracks'])} stems to {stem_dir}")
+            console.info(f"Full mix: {result['full_mix']}")
+        else:
+            console.info("No loop files found for stem export.")
+    elif template:
         from dodgylegally.strategies.templates import load_template, apply_template
         tmpl = load_template(template)
         os.makedirs(output_dir, exist_ok=True)

--- a/src/dodgylegally/cli.py
+++ b/src/dodgylegally/cli.py
@@ -188,8 +188,9 @@ def process(ctx, input_path, effects, target_bpm, stretch, pitch, target_key):
 @cli.command()
 @click.option("--input", "-i", "input_dir", default=None, help="Directory with loop files. Defaults to <output>/loop/.")
 @click.option("--repeats", "-r", default="3-4", help="Repeat range for each loop (e.g. 3-4).")
+@click.option("--strategy", "-s", default="sequential", help="Arrangement strategy (sequential, loudness, tempo, key_compatible, layered).")
 @click.pass_context
-def combine(ctx, input_dir, repeats):
+def combine(ctx, input_dir, repeats, strategy):
     """Merge loop files into a combined file."""
     import os
     from dodgylegally.combine import combine_loops
@@ -202,7 +203,7 @@ def combine(ctx, input_dir, repeats):
     output_dir = os.path.join(base, "combined")
 
     console = ctx.obj["console"]
-    result = combine_loops(input_dir, output_dir, repeats=repeat_range)
+    result = combine_loops(input_dir, output_dir, repeats=repeat_range, strategy=strategy)
     if result:
         console.info(f"Combined loop: {result}")
     else:

--- a/src/dodgylegally/combine.py
+++ b/src/dodgylegally/combine.py
@@ -5,11 +5,20 @@ import random
 from pydub import AudioSegment
 
 
-def combine_loops(loop_dir: str, output_dir: str, repeats: tuple[int, int] = (3, 4)) -> str | None:
-    """Combine all loops into a versioned file. Returns output path, or None if no loops."""
+def combine_loops(loop_dir: str, output_dir: str, repeats: tuple[int, int] = (3, 4),
+                  strategy: str = "sequential") -> str | None:
+    """Combine all loops into a versioned file. Returns output path, or None if no loops.
+
+    Uses the named arrangement strategy to order files before combining.
+    """
     wav_files = glob.glob(os.path.join(loop_dir, "*.wav"))
     if not wav_files:
         return None
+
+    # Apply arrangement strategy
+    from dodgylegally.strategies import get_strategy
+    strat = get_strategy(strategy)
+    wav_files = strat.arrange(wav_files)
 
     os.makedirs(output_dir, exist_ok=True)
     combined = AudioSegment.empty()

--- a/src/dodgylegally/stems.py
+++ b/src/dodgylegally/stems.py
@@ -1,0 +1,78 @@
+"""Multi-track stem export — individual stems + manifest alongside full mix."""
+
+from __future__ import annotations
+
+import glob
+import json
+import os
+import random
+
+from pydub import AudioSegment
+
+
+def export_stems(loop_dir: str, output_dir: str, repeats: tuple[int, int] = (3, 4),
+                 strategy: str = "sequential") -> dict:
+    """Export individual stems and a full mix from loop files.
+
+    Returns a dict with 'tracks' (list of track info) and 'full_mix' (path).
+    """
+    wav_files = sorted(glob.glob(os.path.join(loop_dir, "*.wav")))
+
+    os.makedirs(output_dir, exist_ok=True)
+
+    if not wav_files:
+        manifest = {"tracks": [], "full_mix": None}
+        manifest_path = os.path.join(output_dir, "manifest.json")
+        Path_obj = os.path.join(output_dir, "manifest.json")
+        with open(manifest_path, "w") as f:
+            json.dump(manifest, f, indent=2)
+        return manifest
+
+    # Apply strategy for ordering
+    from dodgylegally.strategies import get_strategy
+    strat = get_strategy(strategy)
+    wav_files = strat.arrange(wav_files)
+
+    tracks = []
+    combined = AudioSegment.empty()
+    current_ms = 0
+
+    for i, filepath in enumerate(wav_files):
+        sound = AudioSegment.from_file(filepath, format="wav")
+        repeat_count = random.randint(repeats[0], repeats[1])
+        stem_audio = sound * repeat_count
+        stem_duration = len(stem_audio)
+
+        # Export individual stem
+        stem_name = f"stem_{i + 1:03d}_{os.path.basename(filepath)}"
+        stem_path = os.path.join(output_dir, stem_name)
+        stem_audio.export(stem_path, format="wav")
+
+        tracks.append({
+            "index": i + 1,
+            "source": os.path.basename(filepath),
+            "stem_file": stem_name,
+            "start_ms": current_ms,
+            "duration_ms": stem_duration,
+            "repeats": repeat_count,
+        })
+
+        combined += stem_audio
+        current_ms += stem_duration
+
+    # Export full mix
+    mix_path = os.path.join(output_dir, "full_mix.wav")
+    combined.export(mix_path, format="wav")
+
+    # Write manifest
+    manifest = {
+        "tracks": tracks,
+        "full_mix": mix_path,
+        "total_duration_ms": len(combined),
+        "track_count": len(tracks),
+    }
+    manifest_path = os.path.join(output_dir, "manifest.json")
+    with open(manifest_path, "w") as f:
+        json.dump(manifest, f, indent=2, default=str)
+
+    return manifest

--- a/src/dodgylegally/strategies/__init__.py
+++ b/src/dodgylegally/strategies/__init__.py
@@ -1,0 +1,40 @@
+"""Arrangement strategy registry — get_strategy, list_strategies, register_strategy."""
+
+from __future__ import annotations
+
+from dodgylegally.strategies.base import ArrangementStrategy
+
+_REGISTRY: dict[str, type] = {}
+
+
+def register_strategy(name: str, cls: type) -> None:
+    """Register an ArrangementStrategy implementation by name."""
+    _REGISTRY[name] = cls
+
+
+def get_strategy(name: str) -> ArrangementStrategy:
+    """Return an instance of the named strategy. Raises KeyError if unknown."""
+    if name not in _REGISTRY:
+        raise KeyError(f"Unknown strategy: '{name}'. Available: {', '.join(_REGISTRY)}")
+    return _REGISTRY[name]()
+
+
+def list_strategies() -> list[str]:
+    """Return sorted list of registered strategy names."""
+    return sorted(_REGISTRY.keys())
+
+
+# Register built-in strategies
+from dodgylegally.strategies.builtin import (  # noqa: E402
+    SequentialStrategy,
+    LoudnessStrategy,
+    TempoStrategy,
+    KeyCompatibleStrategy,
+    LayeredStrategy,
+)
+
+register_strategy("sequential", SequentialStrategy)
+register_strategy("loudness", LoudnessStrategy)
+register_strategy("tempo", TempoStrategy)
+register_strategy("key_compatible", KeyCompatibleStrategy)
+register_strategy("layered", LayeredStrategy)

--- a/src/dodgylegally/strategies/base.py
+++ b/src/dodgylegally/strategies/base.py
@@ -1,0 +1,18 @@
+"""Base protocol for arrangement strategies."""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+
+@runtime_checkable
+class ArrangementStrategy(Protocol):
+    """Protocol for sample arrangement strategies."""
+
+    @property
+    def name(self) -> str:
+        ...
+
+    def arrange(self, files: list[str], **kwargs) -> list[str]:
+        """Arrange files according to the strategy. Returns ordered file list."""
+        ...

--- a/src/dodgylegally/strategies/builtin.py
+++ b/src/dodgylegally/strategies/builtin.py
@@ -1,0 +1,133 @@
+"""Built-in arrangement strategies."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+def _read_analysis(filepath: str) -> dict | None:
+    """Read the analysis block from a file's JSON sidecar."""
+    sidecar = Path(filepath).with_suffix(".json")
+    if not sidecar.exists():
+        return None
+    try:
+        data = json.loads(sidecar.read_text())
+        return data.get("analysis")
+    except (json.JSONDecodeError, KeyError):
+        return None
+
+
+class SequentialStrategy:
+    """Keep files in their original (sorted) order."""
+
+    @property
+    def name(self) -> str:
+        return "sequential"
+
+    def arrange(self, files: list[str], **kwargs) -> list[str]:
+        return sorted(files)
+
+
+class LoudnessStrategy:
+    """Order files by LUFS loudness."""
+
+    @property
+    def name(self) -> str:
+        return "loudness"
+
+    def arrange(self, files: list[str], **kwargs) -> list[str]:
+        descending = kwargs.get("descending", False)
+
+        def _lufs(f: str) -> float:
+            analysis = _read_analysis(f)
+            if analysis and "loudness_lufs" in analysis:
+                return analysis["loudness_lufs"]
+            return -70.0  # unknown = very quiet
+
+        return sorted(files, key=_lufs, reverse=descending)
+
+
+class TempoStrategy:
+    """Group files by similar BPM."""
+
+    @property
+    def name(self) -> str:
+        return "tempo"
+
+    def arrange(self, files: list[str], **kwargs) -> list[str]:
+        def _bpm(f: str) -> float:
+            analysis = _read_analysis(f)
+            if analysis and analysis.get("bpm"):
+                return analysis["bpm"]
+            return 0.0
+
+        return sorted(files, key=_bpm)
+
+
+class KeyCompatibleStrategy:
+    """Group files by harmonically compatible keys.
+
+    Uses the circle of fifths distance to sort keys so that
+    related keys (e.g., C major / A minor) are adjacent.
+    """
+
+    # Circle of fifths ordering for major keys
+    _CIRCLE = ["C", "G", "D", "A", "E", "B", "F#", "C#", "G#", "D#", "A#", "F"]
+
+    # Relative minor for each major key
+    _RELATIVE_MINOR = {
+        "C": "A", "G": "E", "D": "B", "A": "F#", "E": "C#", "B": "G#",
+        "F#": "D#", "C#": "A#", "G#": "F", "D#": "C", "A#": "G", "F": "D",
+    }
+
+    @property
+    def name(self) -> str:
+        return "key_compatible"
+
+    def _key_sort_value(self, key_str: str | None) -> float:
+        """Map a key string to a sort value on the circle of fifths."""
+        if not key_str:
+            return 99.0  # unknown keys last
+
+        parts = key_str.split()
+        root = parts[0]
+        mode = parts[1] if len(parts) > 1 else "major"
+
+        # For minor keys, map to their relative major position
+        if mode == "minor":
+            for major, minor in self._RELATIVE_MINOR.items():
+                if minor == root:
+                    root = major
+                    break
+            # Add a small offset so minor sorts just after its relative major
+            try:
+                return self._CIRCLE.index(root) + 0.5
+            except ValueError:
+                return 99.0
+
+        try:
+            return float(self._CIRCLE.index(root))
+        except ValueError:
+            return 99.0
+
+    def arrange(self, files: list[str], **kwargs) -> list[str]:
+        def _key_val(f: str) -> float:
+            analysis = _read_analysis(f)
+            if analysis and analysis.get("key"):
+                return self._key_sort_value(analysis["key"])
+            return 99.0
+
+        return sorted(files, key=_key_val)
+
+
+class LayeredStrategy:
+    """Return files grouped for layered overlay (no reordering, just grouping)."""
+
+    @property
+    def name(self) -> str:
+        return "layered"
+
+    def arrange(self, files: list[str], **kwargs) -> list[str]:
+        # Layered just returns all files — the combine step handles overlay logic
+        return sorted(files)

--- a/src/dodgylegally/strategies/templates.py
+++ b/src/dodgylegally/strategies/templates.py
@@ -1,0 +1,122 @@
+"""Arrangement templates — YAML-defined section-based compositions."""
+
+from __future__ import annotations
+
+import glob
+import os
+import random
+from pathlib import Path
+
+import yaml
+from pydub import AudioSegment
+
+from dodgylegally.strategies import get_strategy
+
+
+def _bundled_dir() -> Path:
+    """Return the path to bundled templates."""
+    return Path(__file__).resolve().parent.parent / "templates"
+
+
+def _user_dir() -> Path:
+    """Return the user templates directory."""
+    return Path.home() / ".config" / "dodgylegally" / "templates"
+
+
+def load_template(name: str, search_dirs: list[Path] | None = None) -> dict:
+    """Load a template by name from bundled or user directories.
+
+    Raises FileNotFoundError if the template doesn't exist.
+    """
+    dirs = search_dirs or [_user_dir(), _bundled_dir()]
+
+    for d in dirs:
+        path = d / f"{name}.yaml"
+        if path.exists():
+            return yaml.safe_load(path.read_text())
+
+    available = list_templates(search_dirs)
+    raise FileNotFoundError(
+        f"Template '{name}' not found. Available: {', '.join(available)}"
+    )
+
+
+def list_templates(search_dirs: list[Path] | None = None) -> list[str]:
+    """Return sorted list of available template names."""
+    dirs = search_dirs or [_user_dir(), _bundled_dir()]
+    names = set()
+    for d in dirs:
+        if d.exists():
+            for f in d.glob("*.yaml"):
+                names.add(f.stem)
+    return sorted(names)
+
+
+def apply_template(template: dict, loop_dir: str, output_path: str,
+                   repeats: tuple[int, int] = (3, 4)) -> str:
+    """Apply a template to loop files and produce a combined output.
+
+    Each section uses its declared strategy to order a subset of files,
+    then concatenates them (with repeats) up to the section's duration.
+
+    Files are distributed across sections round-robin style. If there
+    are fewer files than sections, files are reused.
+    """
+    wav_files = sorted(glob.glob(os.path.join(loop_dir, "*.wav")))
+    if not wav_files:
+        # Create a silent placeholder
+        silence = AudioSegment.silent(duration=1000)
+        silence.export(output_path, format="wav")
+        return output_path
+
+    sections = template.get("sections", [])
+    if not sections:
+        sections = [{"name": "default", "strategy": "sequential", "duration_s": 10}]
+
+    # Distribute files across sections
+    file_groups = _distribute_files(wav_files, len(sections))
+
+    combined = AudioSegment.empty()
+
+    for i, section in enumerate(sections):
+        strategy_name = section.get("strategy", "sequential")
+        duration_s = section.get("duration_s", 8)
+        kwargs = section.get("kwargs", {})
+        target_ms = int(duration_s * 1000)
+
+        # Get files for this section (may be empty if few files)
+        section_files = file_groups[i] if i < len(file_groups) else wav_files
+
+        if not section_files:
+            section_files = wav_files  # fallback: use all files
+
+        # Apply strategy
+        strategy = get_strategy(strategy_name)
+        ordered = strategy.arrange(section_files, **kwargs)
+
+        # Build section audio up to target duration
+        section_audio = AudioSegment.empty()
+        for filepath in ordered:
+            if len(section_audio) >= target_ms:
+                break
+            sound = AudioSegment.from_file(filepath, format="wav")
+            repeat_count = random.randint(repeats[0], repeats[1])
+            section_audio += sound * repeat_count
+
+        # Trim to target duration
+        if len(section_audio) > target_ms:
+            section_audio = section_audio[:target_ms]
+
+        combined += section_audio
+
+    os.makedirs(os.path.dirname(output_path) or ".", exist_ok=True)
+    combined.export(output_path, format="wav")
+    return output_path
+
+
+def _distribute_files(files: list[str], n_groups: int) -> list[list[str]]:
+    """Distribute files across n groups round-robin."""
+    groups: list[list[str]] = [[] for _ in range(n_groups)]
+    for i, f in enumerate(files):
+        groups[i % n_groups].append(f)
+    return groups

--- a/src/dodgylegally/templates/ambient-drift.yaml
+++ b/src/dodgylegally/templates/ambient-drift.yaml
@@ -1,0 +1,14 @@
+name: ambient-drift
+description: Slow harmonic wandering. Key-compatible ordering with long repeats.
+sections:
+  - name: opening
+    strategy: key_compatible
+    duration_s: 12
+  - name: middle
+    strategy: loudness
+    duration_s: 10
+    kwargs:
+      descending: false
+  - name: close
+    strategy: key_compatible
+    duration_s: 10

--- a/src/dodgylegally/templates/build-and-drop.yaml
+++ b/src/dodgylegally/templates/build-and-drop.yaml
@@ -1,0 +1,19 @@
+name: build-and-drop
+description: Quiet intro builds to a layered climax, then drops away.
+sections:
+  - name: intro
+    strategy: loudness
+    duration_s: 8
+    kwargs:
+      descending: false
+  - name: build
+    strategy: tempo
+    duration_s: 6
+  - name: drop
+    strategy: layered
+    duration_s: 4
+  - name: outro
+    strategy: loudness
+    duration_s: 6
+    kwargs:
+      descending: true

--- a/src/dodgylegally/templates/chaos.yaml
+++ b/src/dodgylegally/templates/chaos.yaml
@@ -1,0 +1,15 @@
+name: chaos
+description: No logic. Sequential order, short sections, rapid transitions.
+sections:
+  - name: burst-1
+    strategy: sequential
+    duration_s: 3
+  - name: burst-2
+    strategy: sequential
+    duration_s: 3
+  - name: burst-3
+    strategy: sequential
+    duration_s: 3
+  - name: burst-4
+    strategy: sequential
+    duration_s: 3

--- a/src/dodgylegally/templates/rhythmic-collage.yaml
+++ b/src/dodgylegally/templates/rhythmic-collage.yaml
@@ -1,0 +1,15 @@
+name: rhythmic-collage
+description: Tempo-grouped sections with percussive energy.
+sections:
+  - name: slow
+    strategy: tempo
+    duration_s: 6
+  - name: medium
+    strategy: tempo
+    duration_s: 8
+  - name: fast
+    strategy: tempo
+    duration_s: 6
+  - name: breakdown
+    strategy: layered
+    duration_s: 4

--- a/tests/test_stems.py
+++ b/tests/test_stems.py
@@ -1,0 +1,132 @@
+"""Tests for multi-track stem export."""
+
+import json
+from pathlib import Path
+
+import pytest
+from pydub.generators import Sine
+
+
+def _make_wav(path: Path, freq: float = 440.0, duration_ms: int = 1000):
+    """Generate a sine wave WAV file."""
+    seg = Sine(freq).to_audio_segment(duration=duration_ms).apply_gain(-10)
+    seg.export(str(path), format="wav")
+    return path
+
+
+def test_export_stems_creates_files(tmp_path):
+    """export_stems creates individual stem WAV files."""
+    from dodgylegally.stems import export_stems
+
+    loop_dir = tmp_path / "loops"
+    loop_dir.mkdir()
+    for name in ["a.wav", "b.wav", "c.wav"]:
+        _make_wav(loop_dir / name, duration_ms=500)
+
+    stem_dir = tmp_path / "stems"
+    result = export_stems(str(loop_dir), str(stem_dir))
+
+    assert (stem_dir).exists()
+    stem_files = list(stem_dir.glob("stem_*.wav"))
+    assert len(stem_files) == 3
+
+
+def test_export_stems_creates_manifest(tmp_path):
+    """export_stems creates a manifest.json."""
+    from dodgylegally.stems import export_stems
+
+    loop_dir = tmp_path / "loops"
+    loop_dir.mkdir()
+    for name in ["a.wav", "b.wav"]:
+        _make_wav(loop_dir / name, duration_ms=500)
+
+    stem_dir = tmp_path / "stems"
+    export_stems(str(loop_dir), str(stem_dir))
+
+    manifest_path = stem_dir / "manifest.json"
+    assert manifest_path.exists()
+
+    manifest = json.loads(manifest_path.read_text())
+    assert "tracks" in manifest
+    assert len(manifest["tracks"]) == 2
+
+
+def test_manifest_has_timing_info(tmp_path):
+    """Manifest tracks include start_ms and duration_ms."""
+    from dodgylegally.stems import export_stems
+
+    loop_dir = tmp_path / "loops"
+    loop_dir.mkdir()
+    _make_wav(loop_dir / "clip.wav", duration_ms=1000)
+
+    stem_dir = tmp_path / "stems"
+    export_stems(str(loop_dir), str(stem_dir), repeats=(2, 2))
+
+    manifest = json.loads((stem_dir / "manifest.json").read_text())
+    track = manifest["tracks"][0]
+
+    assert "start_ms" in track
+    assert "duration_ms" in track
+    assert "source" in track
+    assert "stem_file" in track
+    assert track["start_ms"] == 0
+    assert track["duration_ms"] > 0
+
+
+def test_export_stems_creates_full_mix(tmp_path):
+    """export_stems also creates a full mix WAV."""
+    from dodgylegally.stems import export_stems
+
+    loop_dir = tmp_path / "loops"
+    loop_dir.mkdir()
+    _make_wav(loop_dir / "a.wav", duration_ms=500)
+    _make_wav(loop_dir / "b.wav", duration_ms=500)
+
+    stem_dir = tmp_path / "stems"
+    result = export_stems(str(loop_dir), str(stem_dir))
+
+    assert "full_mix" in result
+    assert Path(result["full_mix"]).exists()
+
+
+def test_export_stems_empty_dir(tmp_path):
+    """export_stems returns empty result for empty directory."""
+    from dodgylegally.stems import export_stems
+
+    loop_dir = tmp_path / "loops"
+    loop_dir.mkdir()
+
+    stem_dir = tmp_path / "stems"
+    result = export_stems(str(loop_dir), str(stem_dir))
+
+    assert result["tracks"] == []
+
+
+def test_manifest_timing_is_sequential(tmp_path):
+    """Manifest track start times are sequential (non-overlapping)."""
+    from dodgylegally.stems import export_stems
+
+    loop_dir = tmp_path / "loops"
+    loop_dir.mkdir()
+    for name in ["a.wav", "b.wav", "c.wav"]:
+        _make_wav(loop_dir / name, duration_ms=500)
+
+    stem_dir = tmp_path / "stems"
+    export_stems(str(loop_dir), str(stem_dir), repeats=(1, 1))
+
+    manifest = json.loads((stem_dir / "manifest.json").read_text())
+    tracks = manifest["tracks"]
+
+    for i in range(1, len(tracks)):
+        prev_end = tracks[i - 1]["start_ms"] + tracks[i - 1]["duration_ms"]
+        assert tracks[i]["start_ms"] == prev_end
+
+
+def test_cli_combine_accepts_stems_flag():
+    """CLI combine subcommand accepts --stems flag."""
+    from click.testing import CliRunner
+    from dodgylegally.cli import cli
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["combine", "--help"])
+    assert "--stems" in result.output

--- a/tests/test_strategies.py
+++ b/tests/test_strategies.py
@@ -1,0 +1,188 @@
+"""Tests for arrangement strategies."""
+
+import json
+import numpy as np
+import soundfile as sf
+from pathlib import Path
+
+import pytest
+from pydub import AudioSegment
+from pydub.generators import Sine
+
+
+def _make_wav(path: Path, freq: float = 440.0, duration_ms: int = 1000, amplitude: float = 0.5):
+    """Generate a sine wave WAV file via pydub."""
+    seg = Sine(freq).to_audio_segment(duration=duration_ms).apply_gain(-10 if amplitude > 0.3 else -30)
+    seg.export(str(path), format="wav")
+    return path
+
+
+def _make_wav_with_analysis(path: Path, freq: float = 440.0, duration_ms: int = 1000,
+                             bpm: float = 120.0, key: str = "C major", lufs: float = -12.0):
+    """Generate a WAV and write a fake analysis sidecar for strategy testing."""
+    _make_wav(path, freq=freq, duration_ms=duration_ms)
+    sidecar = path.with_suffix(".json")
+    sidecar.write_text(json.dumps({
+        "analysis": {
+            "bpm": bpm, "key": key, "loudness_lufs": lufs,
+            "duration_ms": duration_ms, "spectral_centroid": freq,
+            "rms_energy": 0.1, "zero_crossing_rate": 0.05,
+        }
+    }, indent=2))
+    return path
+
+
+# --- Registry Tests ---
+
+
+def test_strategy_registry_has_builtins():
+    """Strategy registry contains all built-in strategies."""
+    from dodgylegally.strategies import list_strategies
+
+    names = list_strategies()
+    assert "sequential" in names
+    assert "loudness" in names
+    assert "layered" in names
+
+
+def test_get_strategy_returns_instance():
+    """get_strategy returns an ArrangementStrategy instance."""
+    from dodgylegally.strategies import get_strategy
+    from dodgylegally.strategies.base import ArrangementStrategy
+
+    strategy = get_strategy("sequential")
+    assert isinstance(strategy, ArrangementStrategy)
+
+
+def test_get_strategy_unknown_raises():
+    """get_strategy raises KeyError for unknown strategies."""
+    from dodgylegally.strategies import get_strategy
+
+    with pytest.raises(KeyError):
+        get_strategy("nonexistent_strategy")
+
+
+# --- Sequential Strategy ---
+
+
+def test_sequential_preserves_order(tmp_path):
+    """Sequential strategy keeps files in their original order."""
+    from dodgylegally.strategies import get_strategy
+
+    files = []
+    for i, name in enumerate(["aaa.wav", "bbb.wav", "ccc.wav"]):
+        f = _make_wav(tmp_path / name, freq=200 + i * 200)
+        files.append(str(f))
+
+    strategy = get_strategy("sequential")
+    ordered = strategy.arrange(files)
+    assert [Path(f).name for f in ordered] == ["aaa.wav", "bbb.wav", "ccc.wav"]
+
+
+# --- Loudness Strategy ---
+
+
+def test_loudness_orders_by_lufs(tmp_path):
+    """Loudness strategy orders files quiet-to-loud by default."""
+    from dodgylegally.strategies import get_strategy
+
+    _make_wav_with_analysis(tmp_path / "loud.wav", lufs=-6.0)
+    _make_wav_with_analysis(tmp_path / "medium.wav", lufs=-12.0)
+    _make_wav_with_analysis(tmp_path / "quiet.wav", lufs=-24.0)
+
+    files = [str(tmp_path / "loud.wav"), str(tmp_path / "medium.wav"), str(tmp_path / "quiet.wav")]
+    strategy = get_strategy("loudness")
+    ordered = strategy.arrange(files)
+
+    names = [Path(f).name for f in ordered]
+    assert names == ["quiet.wav", "medium.wav", "loud.wav"]
+
+
+def test_loudness_descending(tmp_path):
+    """Loudness strategy with descending=True orders loud-to-quiet."""
+    from dodgylegally.strategies import get_strategy
+
+    _make_wav_with_analysis(tmp_path / "loud.wav", lufs=-6.0)
+    _make_wav_with_analysis(tmp_path / "quiet.wav", lufs=-24.0)
+
+    files = [str(tmp_path / "quiet.wav"), str(tmp_path / "loud.wav")]
+    strategy = get_strategy("loudness")
+    ordered = strategy.arrange(files, descending=True)
+
+    names = [Path(f).name for f in ordered]
+    assert names == ["loud.wav", "quiet.wav"]
+
+
+# --- Tempo Strategy ---
+
+
+def test_tempo_groups_by_similar_bpm(tmp_path):
+    """Tempo strategy groups files with similar BPM together."""
+    from dodgylegally.strategies import get_strategy
+
+    _make_wav_with_analysis(tmp_path / "fast.wav", bpm=140.0)
+    _make_wav_with_analysis(tmp_path / "slow.wav", bpm=80.0)
+    _make_wav_with_analysis(tmp_path / "fast2.wav", bpm=138.0)
+
+    files = [str(tmp_path / "fast.wav"), str(tmp_path / "slow.wav"), str(tmp_path / "fast2.wav")]
+    strategy = get_strategy("tempo")
+    ordered = strategy.arrange(files)
+
+    # fast and fast2 should be adjacent
+    names = [Path(f).name for f in ordered]
+    fast_idx = names.index("fast.wav")
+    fast2_idx = names.index("fast2.wav")
+    assert abs(fast_idx - fast2_idx) == 1
+
+
+# --- Key Compatible Strategy ---
+
+
+def test_key_compatible_groups_related_keys(tmp_path):
+    """Key-compatible strategy groups harmonically related keys."""
+    from dodgylegally.strategies import get_strategy
+
+    _make_wav_with_analysis(tmp_path / "c_major.wav", key="C major")
+    _make_wav_with_analysis(tmp_path / "a_minor.wav", key="A minor")
+    _make_wav_with_analysis(tmp_path / "fsharp_major.wav", key="F# major")
+
+    files = [str(tmp_path / f) for f in ["c_major.wav", "fsharp_major.wav", "a_minor.wav"]]
+    strategy = get_strategy("key_compatible")
+    ordered = strategy.arrange(files)
+
+    # C major and A minor are relative keys — should be adjacent
+    names = [Path(f).name for f in ordered]
+    c_idx = names.index("c_major.wav")
+    a_idx = names.index("a_minor.wav")
+    assert abs(c_idx - a_idx) == 1
+
+
+# --- Layered Strategy ---
+
+
+def test_layered_produces_output(tmp_path):
+    """Layered strategy produces an AudioSegment combining files."""
+    from dodgylegally.strategies import get_strategy
+
+    for name in ["a.wav", "b.wav", "c.wav"]:
+        _make_wav(tmp_path / name, duration_ms=500)
+
+    files = [str(tmp_path / f) for f in ["a.wav", "b.wav", "c.wav"]]
+    strategy = get_strategy("layered")
+    result = strategy.arrange(files, max_layers=2)
+
+    assert isinstance(result, list)
+    assert len(result) > 0
+
+
+# --- CLI ---
+
+
+def test_cli_combine_accepts_strategy_flag():
+    """CLI combine subcommand accepts --strategy flag."""
+    from click.testing import CliRunner
+    from dodgylegally.cli import cli
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["combine", "--help"])
+    assert "--strategy" in result.output

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -1,0 +1,108 @@
+"""Tests for arrangement templates."""
+
+import json
+from pathlib import Path
+
+import pytest
+from pydub.generators import Sine
+
+
+def _make_wav(path: Path, freq: float = 440.0, duration_ms: int = 1000):
+    """Generate a sine wave WAV file."""
+    seg = Sine(freq).to_audio_segment(duration=duration_ms).apply_gain(-10)
+    seg.export(str(path), format="wav")
+    return path
+
+
+def _make_wav_with_analysis(path: Path, freq: float = 440.0, duration_ms: int = 1000,
+                             bpm: float = 120.0, key: str = "C major", lufs: float = -12.0):
+    """Generate a WAV and write a fake analysis sidecar."""
+    _make_wav(path, freq=freq, duration_ms=duration_ms)
+    sidecar = path.with_suffix(".json")
+    sidecar.write_text(json.dumps({
+        "analysis": {
+            "bpm": bpm, "key": key, "loudness_lufs": lufs,
+            "duration_ms": duration_ms, "spectral_centroid": freq,
+            "rms_energy": 0.1, "zero_crossing_rate": 0.05,
+        }
+    }, indent=2))
+    return path
+
+
+def test_load_template_bundled():
+    """load_template loads a bundled template by name."""
+    from dodgylegally.strategies.templates import load_template
+
+    template = load_template("build-and-drop")
+    assert "sections" in template
+    assert len(template["sections"]) > 0
+
+
+def test_load_template_missing_raises():
+    """load_template raises FileNotFoundError for unknown templates."""
+    from dodgylegally.strategies.templates import load_template
+
+    with pytest.raises(FileNotFoundError):
+        load_template("nonexistent_template")
+
+
+def test_list_templates_includes_builtins():
+    """list_templates returns bundled template names."""
+    from dodgylegally.strategies.templates import list_templates
+
+    names = list_templates()
+    assert "build-and-drop" in names
+    assert "ambient-drift" in names
+
+
+def test_template_section_has_required_fields():
+    """Each template section has strategy and duration_s."""
+    from dodgylegally.strategies.templates import load_template
+
+    template = load_template("build-and-drop")
+    for section in template["sections"]:
+        assert "name" in section
+        assert "strategy" in section
+        assert "duration_s" in section
+
+
+def test_apply_template_produces_output(tmp_path):
+    """apply_template creates an output WAV file."""
+    from dodgylegally.strategies.templates import load_template, apply_template
+
+    # Create sample files with analysis
+    loop_dir = tmp_path / "loops"
+    loop_dir.mkdir()
+    for i, name in enumerate(["a.wav", "b.wav", "c.wav", "d.wav"]):
+        _make_wav_with_analysis(loop_dir / name, freq=200 + i * 100, lufs=-20 + i * 3)
+
+    template = load_template("build-and-drop")
+    out = tmp_path / "out.wav"
+
+    result = apply_template(template, str(loop_dir), str(out))
+    assert Path(result).exists()
+
+
+def test_apply_template_with_few_files(tmp_path):
+    """apply_template works even with fewer files than sections."""
+    from dodgylegally.strategies.templates import load_template, apply_template
+
+    loop_dir = tmp_path / "loops"
+    loop_dir.mkdir()
+    _make_wav_with_analysis(loop_dir / "only.wav", lufs=-12.0)
+
+    template = load_template("build-and-drop")
+    out = tmp_path / "out.wav"
+
+    result = apply_template(template, str(loop_dir), str(out))
+    assert Path(result).exists()
+
+
+def test_cli_combine_accepts_template_flag():
+    """CLI combine subcommand accepts --template flag."""
+    from click.testing import CliRunner
+    from dodgylegally.cli import cli
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["combine", "--help"])
+    assert "--template" in result.output


### PR DESCRIPTION
## Summary

Phase 4 completes the roadmap. The combine step is no longer a simple concatenator — it reasons about the audio it holds and can compose structured, sectioned pieces.

- **Arrangement strategies** — 5 pluggable strategies: sequential (default), loudness (LUFS ordering), tempo (BPM grouping), key_compatible (circle-of-fifths), layered. Protocol-based registry. `--strategy` flag on combine. (#14)
- **Arrangement templates** — YAML-defined section-based compositions. 4 bundled templates: build-and-drop, ambient-drift, rhythmic-collage, chaos. Each section declares a strategy, duration, and kwargs. `--template` flag on combine. (#15)
- **Multi-track stem export** — Individual stem WAV files + manifest.json with track listing, timing, and metadata. `--stems` flag on combine. (#16)

## Test plan

- [ ] 168 tests pass (`pytest tests/ -v`)
- [ ] `dodgylegally combine --strategy loudness` orders by LUFS
- [ ] `dodgylegally combine --template build-and-drop` creates sectioned composition
- [ ] `dodgylegally combine --stems` exports stems + manifest.json
- [ ] All 16 issues closed across 4 phases